### PR TITLE
use `typesBundle` for api options

### DIFF
--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/api-derive",
-  "version": "6.0.5",
+  "version": "6.0.6-8",
   "description": "Additional polkadot.js derives for Acala Network",
   "author": "Acala Developers <hello@acala.network>",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@acala-network/types": "6.0.5"
+    "@acala-network/types": "6.0.6-8"
   },
   "peerDependencies": {
     "@polkadot/api": "^10.9.1"

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/api-derive",
-  "version": "6.0.6-8",
+  "version": "6.1.0",
   "description": "Additional polkadot.js derives for Acala Network",
   "author": "Acala Developers <hello@acala.network>",
   "license": "Apache-2.0",
@@ -23,7 +23,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@acala-network/types": "6.0.6-8"
+    "@acala-network/types": "6.1.0"
   },
   "peerDependencies": {
     "@polkadot/api": "^10.9.1"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/api",
-  "version": "6.0.6-8",
+  "version": "6.1.0",
   "description": "Acala JS API",
   "author": "Acala Developers <hello@acala.network>",
   "license": "Apache-2.0",
@@ -23,8 +23,8 @@
     "publish:manual": "npm publish --tolerate-republish --access public"
   },
   "dependencies": {
-    "@acala-network/api-derive": "6.0.6-8",
-    "@acala-network/types": "6.0.6-8"
+    "@acala-network/api-derive": "6.1.0",
+    "@acala-network/types": "6.1.0"
   },
   "peerDependencies": {
     "@polkadot/api": "^10.9.1"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/api",
-  "version": "6.0.5",
+  "version": "6.0.6-8",
   "description": "Acala JS API",
   "author": "Acala Developers <hello@acala.network>",
   "license": "Apache-2.0",
@@ -23,8 +23,8 @@
     "publish:manual": "npm publish --tolerate-republish --access public"
   },
   "dependencies": {
-    "@acala-network/api-derive": "6.0.5",
-    "@acala-network/types": "6.0.5"
+    "@acala-network/api-derive": "6.0.6-8",
+    "@acala-network/types": "6.0.6-8"
   },
   "peerDependencies": {
     "@polkadot/api": "^10.9.1"

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,67 +1,10 @@
+import { acalaRuntime, acalaTypesBundle } from '@acala-network/types';
 import type { ApiOptions } from '@polkadot/api/types';
-import type { RegistryTypes } from '@polkadot/types/types';
 
-import { acalaDerives } from '@acala-network/api-derive';
-import {
-  acalaLookupTypes,
-  acalaRpc,
-  acalaRuntime,
-  acalaSignedExtensions,
-  acalaTypes,
-  acalaTypesAlias,
-  acalaTypesBundle,
-} from '@acala-network/types';
-
-export const options = ({ derives = {},
-  rpc = {},
-  runtime = {},
-  signedExtensions,
-  types = {},
-  typesAlias = {},
-  typesBundle = {},
-  ...otherOptions }: ApiOptions = {}): ApiOptions => ({
-  types: {
-    ...acalaTypes as unknown as RegistryTypes,
-    ...acalaLookupTypes as unknown as RegistryTypes,
-    ...types,
-  },
-  runtime: {
-    ...acalaRuntime,
-    ...runtime,
-  },
-  rpc: {
-    ...acalaRpc,
-    ...rpc,
-  },
-  typesAlias: {
-    ...acalaTypesAlias,
-    ...typesAlias,
-  },
-  derives: {
-    ...acalaDerives,
-    ...derives,
-  },
-  typesBundle: {
-    spec: {
-      ...typesBundle.spec,
-      acala: {
-        ...acalaTypesBundle.spec.acala,
-        ...typesBundle?.spec?.acala,
-      },
-      mandala: {
-        ...acalaTypesBundle.spec.mandala,
-        ...typesBundle?.spec?.mandala,
-      },
-      karura: {
-        ...acalaTypesBundle.spec.karura,
-        ...typesBundle?.spec?.mandala,
-      },
-    },
-    ...typesBundle,
-  },
-  signedExtensions: {
-    ...acalaSignedExtensions,
-    ...signedExtensions,
-  },
-  ...otherOptions,
+export const options = ({ provider }: ApiOptions = {}): ApiOptions => ({
+  typesBundle: acalaTypesBundle,
+  runtime: acalaRuntime,
+  provider,
 });
+
+export const withAcalaTypes = options;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,9 +1,8 @@
-import { acalaRuntime, acalaTypesBundle } from '@acala-network/types';
+import { acalaTypesBundle } from '@acala-network/types';
 import type { ApiOptions } from '@polkadot/api/types';
 
 export const options = ({ provider }: ApiOptions = {}): ApiOptions => ({
   typesBundle: acalaTypesBundle,
-  runtime: acalaRuntime,
   provider,
 });
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/types",
-  "version": "6.0.6-8",
+  "version": "6.1.0",
   "description": "Acala types for @polkadot/api",
   "author": "Acala Developers <hello@acala.network>",
   "license": "Apache-2.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/types",
-  "version": "6.0.5",
+  "version": "6.0.6-7",
   "description": "Acala types for @polkadot/api",
   "author": "Acala Developers <hello@acala.network>",
   "license": "Apache-2.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acala-network/types",
-  "version": "6.0.6-7",
+  "version": "6.0.6-8",
   "description": "Acala types for @polkadot/api",
   "author": "Acala Developers <hello@acala.network>",
   "license": "Apache-2.0",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,11 +2,11 @@ import './interfaces/augment-api';
 import './interfaces/augment-types';
 import './interfaces/types-lookup';
 
-import type { OverrideBundleType, OverrideVersionedType } from '@polkadot/types/types';
+import type { OverrideBundleDefinition, OverrideBundleType } from '@polkadot/types/types';
 
 import * as acalaDefs from './interfaces/definitions';
-import { acalaVersioned, karuraVersioned, mandalaVersioned } from './versioned';
 import { jsonrpcFromDefs, typesAliasFromDefs, typesFromDefs } from './utils';
+import { versioned } from './versioned';
 
 export * as acalaLookupTypes from './interfaces/lookup';
 export { acalaSignedExtensions } from './signedExtensions';
@@ -24,36 +24,26 @@ export const acalaRpc = jsonrpcFromDefs(acalaDefs, {});
 export const acalaTypesAlias = typesAliasFromDefs(acalaDefs, {});
 export const acalaRuntime = acalaDefs.runtime.runtime;
 
-function getBundle (versioned: OverrideVersionedType[]) {
-  return {
-    acalaRpc,
-    instances: { council: ['generalCouncil'] },
-    types: [...versioned].map((version) => {
-      return {
-        minmax: version.minmax,
-        types: {
-          ...acalaTypes,
-          ...version.types,
-        },
-      };
-    }),
-    alias: acalaTypesAlias,
-  };
-}
+const sharedBundle: OverrideBundleDefinition = {
+  rpc: acalaRpc,
+  instances: { council: ['generalCouncil'] },
+  types: versioned.map((version) => ({
+    minmax: version.minmax,
+    types: {
+      ...acalaTypes,
+      ...version.types,
+    },
+  })),
+  alias: acalaTypesAlias,
+};
 
-export const acalaTypesBundle = {
+export const acalaTypesBundle: OverrideBundleType = {
   spec: {
-    acala: getBundle(acalaVersioned),
-    mandala: getBundle(mandalaVersioned),
-    karura: getBundle(karuraVersioned),
-  },
-} as unknown as OverrideBundleType;
-
-// Type overrides have priority issues
-export const typesBundleForPolkadot = {
-  spec: {
-    acala: getBundle(acalaVersioned),
-    mandala: getBundle(mandalaVersioned),
-    karura: getBundle(karuraVersioned),
+    acala: sharedBundle,
+    mandala: sharedBundle,
+    karura: sharedBundle,
   },
 };
+
+// Type overrides have priority issues
+export const typesBundleForPolkadot = acalaTypesBundle;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,7 +9,8 @@ import { jsonrpcFromDefs, typesAliasFromDefs, typesFromDefs } from './utils';
 import { versioned } from './versioned';
 
 export * as acalaLookupTypes from './interfaces/lookup';
-export { acalaSignedExtensions } from './signedExtensions';
+import { acalaSignedExtensions } from './signedExtensions';
+export { acalaSignedExtensions };
 
 // FIXME: currently we cannot override this in runtime definations because the code generation script cannot handle overrides
 // This will make it behave correctly in runtime, but wrong types in TS defination.
@@ -35,6 +36,8 @@ const sharedBundle: OverrideBundleDefinition = {
     },
   })),
   alias: acalaTypesAlias,
+  signedExtensions: acalaSignedExtensions,
+  runtime: acalaRuntime,
 };
 
 export const acalaTypesBundle: OverrideBundleType = {

--- a/packages/types/src/versioned.ts
+++ b/packages/types/src/versioned.ts
@@ -241,6 +241,7 @@ const versioned: OverrideVersionedType[] = [
   },
 ];
 
+export { versioned };
 export const acalaVersioned = versioned;
 export const karuraVersioned = versioned;
 export const mandalaVersioned = versioned;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,11 +12,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@acala-network/api-derive@6.0.5, @acala-network/api-derive@workspace:packages/api-derive":
+"@acala-network/api-derive@6.0.6-7, @acala-network/api-derive@workspace:packages/api-derive":
   version: 0.0.0-use.local
   resolution: "@acala-network/api-derive@workspace:packages/api-derive"
   dependencies:
-    "@acala-network/types": 6.0.5
+    "@acala-network/types": 6.0.6-7
     typescript: ^5.0.4
   peerDependencies:
     "@polkadot/api": ^10.9.1
@@ -27,15 +27,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@acala-network/api@workspace:packages/api"
   dependencies:
-    "@acala-network/api-derive": 6.0.5
-    "@acala-network/types": 6.0.5
+    "@acala-network/api-derive": 6.0.6-7
+    "@acala-network/types": 6.0.6-7
     typescript: ^5.0.4
   peerDependencies:
     "@polkadot/api": ^10.9.1
   languageName: unknown
   linkType: soft
 
-"@acala-network/types@6.0.5, @acala-network/types@workspace:packages/types":
+"@acala-network/types@6.0.6-7, @acala-network/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@acala-network/types@workspace:packages/types"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,11 +12,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@acala-network/api-derive@6.0.6-7, @acala-network/api-derive@workspace:packages/api-derive":
+"@acala-network/api-derive@6.0.6-8, @acala-network/api-derive@workspace:packages/api-derive":
   version: 0.0.0-use.local
   resolution: "@acala-network/api-derive@workspace:packages/api-derive"
   dependencies:
-    "@acala-network/types": 6.0.6-7
+    "@acala-network/types": 6.0.6-8
     typescript: ^5.0.4
   peerDependencies:
     "@polkadot/api": ^10.9.1
@@ -27,15 +27,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@acala-network/api@workspace:packages/api"
   dependencies:
-    "@acala-network/api-derive": 6.0.6-7
-    "@acala-network/types": 6.0.6-7
+    "@acala-network/api-derive": 6.0.6-8
+    "@acala-network/types": 6.0.6-8
     typescript: ^5.0.4
   peerDependencies:
     "@polkadot/api": ^10.9.1
   languageName: unknown
   linkType: soft
 
-"@acala-network/types@6.0.6-7, @acala-network/types@workspace:packages/types":
+"@acala-network/types@6.0.6-8, @acala-network/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@acala-network/types@workspace:packages/types"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,11 +12,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@acala-network/api-derive@6.0.6-8, @acala-network/api-derive@workspace:packages/api-derive":
+"@acala-network/api-derive@6.1.0, @acala-network/api-derive@workspace:packages/api-derive":
   version: 0.0.0-use.local
   resolution: "@acala-network/api-derive@workspace:packages/api-derive"
   dependencies:
-    "@acala-network/types": 6.0.6-8
+    "@acala-network/types": 6.1.0
     typescript: ^5.0.4
   peerDependencies:
     "@polkadot/api": ^10.9.1
@@ -27,15 +27,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@acala-network/api@workspace:packages/api"
   dependencies:
-    "@acala-network/api-derive": 6.0.6-8
-    "@acala-network/types": 6.0.6-8
+    "@acala-network/api-derive": 6.1.0
+    "@acala-network/types": 6.1.0
     typescript: ^5.0.4
   peerDependencies:
     "@polkadot/api": ^10.9.1
   languageName: unknown
   linkType: soft
 
-"@acala-network/types@6.0.6-8, @acala-network/types@workspace:packages/types":
+"@acala-network/types@6.1.0, @acala-network/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@acala-network/types@workspace:packages/types"
   dependencies:


### PR DESCRIPTION
## Context
Our api initialization has some issue that it is not able to decode some old blocks. https://github.com/AcalaNetwork/bodhi.js/issues/920

There seems to be some mysterious bug(feature?) that if we pass both `typesBundle` and `types` as apiOptions, it will fail to decode some certain old blocks. 

## Change
To fix the issue and to be more concise, this PR puts everything needed into `typesBundle`, and pass it as the only param to api to avoid conflict.

we keep `options` for backward compatibility, but now we can also initialize api like this
```ts
const api = await new ApiPromise({
  typesBundle: acalaTypesBundle,
  provider,
}
```

## Test
tested with bodhi CI, and everything still works. Decoding old blocks also works now. 
https://github.com/AcalaNetwork/bodhi.js/pull/931

## Question
we don't use `lookupTypes` and `derivedTypes` anymore, what are they, and do we still need them? If we do, should we include them into the bundle, or pass as apiOption?
